### PR TITLE
Separate gender from gender identity or expression

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,8 +12,8 @@ all and expect our code of conduct to be honored. </p>
 
  <p>Our open source community strives to:</p>
 
- <ul> <li><b>Be open</b>: We invite anyone to participate in any aspect of our projects. Our community is open, and any responsibility can be carried by a contributor who demonstrates the
-required capacity and competence.</li> <li><b>Be considerate</b>: People use our work, and we depend on the work of others. Consider users and colleagues before taking action. For example,
+ <ul><li><b>Be open</b>: We invite anyone to participate in any aspect of our projects. Our community is open, and any responsibility can be carried by any contributor.</li>
+ <li><b>Be considerate</b>: People use our work, and we depend on the work of others. Consider users and colleagues before taking action. For example,
 changes to code, infrastructure, policy, and documentation may negatively impact others.</li> <li><b>Be respectful</b>: We expect people to work together to resolve conflict, assume good
 intentions, and act with empathy. Do not turn disagreements into personal attacks.</li> <li><b>Be collaborative</b>: Collaboration reduces redundancy and improves the quality of our work. We
 strive for transparency within our open source community, and we work closely with upstream developers and others in the free software community to coordinate our efforts.</li> <li><b>Be

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@ the letter. </p>
  <h3>Diversity Statement</h3>
 
  <p> We encourage everyone to participate and are committed to building a community for all. Although we may not be able to satisfy everyone, we all agree that everyone is equal. Whenever a participant has made a mistake, we expect them to take responsibility for it. If someone has been harmed or offended, it is our responsibility to listen carefully and respectfully,
-and do our best to right the wrong. </p> <p> Although this list cannot be exhaustive, we explicitly honor diversity in age, culture, ethnicity, gender identity or expression, language, national
+and do our best to right the wrong. </p> <p> Although this list cannot be exhaustive, we explicitly honor diversity in age, gender, gender identity or expression, culture, ethnicity, language, national
 origin, political beliefs, profession, race, religion, sexual orientation, socioeconomic status, and technical ability. We will not tolerate discrimination based on any of the protected
 characteristics above, including participants with disabilities. </p>
 


### PR DESCRIPTION
The geek feminism code of conduct does this (http://geekfeminism.org/about/code-of-conduct/) and I think it helps clarify. I've also moved gender up in the list since it's a big issue right now.